### PR TITLE
BUGS-3249: Add libc6-compat for hub command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add --no-cache --virtual ruby vim
 # Add bash as a separate step
 RUN apk add bash
 
+RUN apk add libc6-compat
 RUN curl -LO https://github.com/github/hub/releases/download/v2.10.0/hub-linux-amd64-2.10.0.tgz && tar xzvf hub-linux-amd64-2.10.0.tgz && ln -s /php-ci/hub-linux-amd64-2.10.0/bin/hub /usr/local/bin/hub
 
 # CircleCI installer doesn't work with /bin/sh, installing bash with apk problematic0


### PR DESCRIPTION
Without this, GitHub's `hub` command doesn't work on Alpine.

Before:
```
$ docker run --rm -it quay.io/pantheon-public/php-ci:4.x hub version 
/usr/local/bin/docker-php-entrypoint: exec: line 9: hub: not found
```
After:
```
$ docker run --rm -it quay.io/pantheon-public/php-ci:4.x-fix-hub hub version
git version 2.18.1
hub version 2.10.0
```

The issue is that `hub` seems to be built with `glibc`, but Alpine uses `musl`. So this change adds the compatibility libraries for `glibc`.

More info: https://github.com/github/hub/issues/1818