### PR TITLE
[LOPS-1850] Update curl and readme.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN echo 'phar.readonly=off' > /usr/local/etc/php/conf.d/phar.ini
 # Collect the components we need for this image
 RUN apk add --no-cache --virtual ruby vim
 
+# Update curl
+RUN apk add --no-cache curl && apk add --upgrade --no-cache curl
+
 # Add bash as a separate step
 RUN apk add bash
 
@@ -24,8 +27,6 @@ RUN curl -LO https://github.com/github/hub/releases/download/v2.10.0/hub-linux-a
 
 # Install a specific version of the CircleCI cli as a workaround for ^^
 RUN curl -LO https://github.com/CircleCI-Public/circleci-cli/releases/download/v0.1.7971/circleci-cli_0.1.7971_linux_amd64.tar.gz && tar xzvf circleci-cli_0.1.7971_linux_amd64.tar.gz && ln -s /php-ci/circleci-cli_0.1.7971_linux_amd64/circleci /usr/local/bin
-
-RUN composer global require -n "hirak/prestissimo:^0.3"
 
 # Add Terminus
 RUN curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install

--- a/README.md
+++ b/README.md
@@ -12,9 +12,13 @@ In CircleCI 2.0:
 ```
 ## Image Contents
 
-- [PHP 7.1](https://github.com/drupal-docker/php/tree/master/7.1)
+- [PHP 7.3](https://github.com/drupal-docker/php/tree/master/7.3)
 - [Terminus](https://github.com/pantheon-systems/terminus)
 - [circle-cli](https://github.com/circle-cli/circle-cli) test tool
+
+## Branches
+- 4.x: Unsupported, some outdated versions, may still receive updates. Used for build-tools plugin testing.
+- Any other branch: Unsupported, unmaintained.
 
 Note that this image does not include any Terminus extensions. See [build-tools-ci image](https://github.com/pantheon-systems/docker-build-tools-ci) for a more complete Docker image pre-populated with a number of useful Terminus plugins. To test a Terminus plugin, use [pantheon-public/terminus-plugin-test](https://quay.io/repository/pantheon-public/terminus-plugin-test).
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ In CircleCI 2.0:
 ## Branches
 - 4.x: Unsupported, some outdated versions, may still receive updates. Used for build-tools plugin testing.
 - v8.2: Unsupported, some outdated versions, may still receive updates.
-- v7.4: Unsupported, some outdated versions, may still receive updates.
 - Any other branch: Unsupported, unmaintained.
 
 Note that this image does not include any Terminus extensions. See [build-tools-ci image](https://github.com/pantheon-systems/docker-build-tools-ci) for a more complete Docker image pre-populated with a number of useful Terminus plugins. To test a Terminus plugin, use [pantheon-public/terminus-plugin-test](https://quay.io/repository/pantheon-public/terminus-plugin-test).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ In CircleCI 2.0:
 
 ## Branches
 - 4.x: Unsupported, some outdated versions, may still receive updates. Used for build-tools plugin testing.
+- v8.2: Unsupported, some outdated versions, may still receive updates.
+- v7.4: Unsupported, some outdated versions, may still receive updates.
 - Any other branch: Unsupported, unmaintained.
 
 Note that this image does not include any Terminus extensions. See [build-tools-ci image](https://github.com/pantheon-systems/docker-build-tools-ci) for a more complete Docker image pre-populated with a number of useful Terminus plugins. To test a Terminus plugin, use [pantheon-public/terminus-plugin-test](https://quay.io/repository/pantheon-public/terminus-plugin-test).


### PR DESCRIPTION
docker php ci 4.x:

Before:

bash-4.4# curl --version
curl 7.61.1 (x86_64-alpine-linux-musl) libcurl/7.61.1 LibreSSL/2.0.0 zlib/1.2.11 libssh2/1.8.0 nghttp2/1.32.0
Release-Date: 2018-09-05
Protocols: dict file ftp ftps gopher http https imap imaps pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: AsynchDNS IPv6 Largefile NTLM NTLM_WB SSL libz HTTP2 UnixSockets HTTPS-proxy


After:


bash-5.1# curl --version
curl 8.4.0 (x86_64-alpine-linux-musl) libcurl/8.4.0 OpenSSL/1.1.1w zlib/1.2.12 brotli/1.0.9 nghttp2/1.46.0
Release-Date: 2023-10-11
Protocols: dict file ftp ftps gopher gophers http https imap imaps mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli HSTS HTTP2 HTTPS-proxy IPv6 Largefile libz NTLM SSL threadsafe TLS-SRP UnixSockets
 