### PR TITLE
[LOPS-1850] Updates to make this image build in 8.2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,8 +114,7 @@ RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 RUN curl -fLSs https://circle.ci/cli | bash
 
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
-RUN apt-get install -y nodejs
-RUN npm install -g npm
+RUN apt-get install -y nodejs npm
 RUN npm install -g yarn
 RUN npm install -g gulp-cli
 RUN npm install -g typescript

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ In CircleCI 2.0/github actions
 ## Branches
 - 4.x: Unsupported, some outdated versions, may still receive updates. Used for build-tools plugin testing.
 - v8.2: Unsupported, some outdated versions, may still receive updates.
-- v7.4: Unsupported, some outdated versions, may still receive updates.
 - Any other branch: Unsupported, unmaintained.
 
 Note that this image does not include any Terminus extensions. See [build-tools-ci image](https://github.com/pantheon-systems/docker-build-tools-ci) for a more complete Docker image pre-populated with a number of useful Terminus plugins. To test a Terminus plugin, use [pantheon-public/terminus-plugin-test](https://quay.io/repository/pantheon-public/terminus-plugin-test).

--- a/README.md
+++ b/README.md
@@ -16,5 +16,11 @@ In CircleCI 2.0/github actions
 - [Terminus](https://github.com/pantheon-systems/terminus)
 - [circle-cli](https://github.com/circle-cli/circle-cli) test tool
 
+## Branches
+- 4.x: Unsupported, some outdated versions, may still receive updates. Used for build-tools plugin testing.
+- v8.2: Unsupported, some outdated versions, may still receive updates.
+- v7.4: Unsupported, some outdated versions, may still receive updates.
+- Any other branch: Unsupported, unmaintained.
+
 Note that this image does not include any Terminus extensions. See [build-tools-ci image](https://github.com/pantheon-systems/docker-build-tools-ci) for a more complete Docker image pre-populated with a number of useful Terminus plugins. To test a Terminus plugin, use [pantheon-public/terminus-plugin-test](https://quay.io/repository/pantheon-public/terminus-plugin-test).
 


### PR DESCRIPTION

Before:

root@24515079a12c:/php-cgi# curl --version
curl 7.74.0 (x86_64-pc-linux-gnu) libcurl/7.74.0 OpenSSL/1.1.1n zlib/1.2.11 brotli/1.0.9 libidn2/2.3.0 libpsl/0.21.0 (+libidn2/2.3.0) libssh2/1.9.0 nghttp2/1.43.0 librtmp/2.3
Release-Date: 2020-12-09
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps mqtt pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli GSS-API HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM NTLM_WB PSL SPNEGO SSL TLS-SRP UnixSockets


root@de1ba54659a8:/php-cgi# dpkg -l | grep curl
ii  curl                               7.74.0-1.3+deb11u3             amd64        command line tool for transferring data with URL syntax
 


After:

curl --version
curl 7.88.1 (aarch64-unknown-linux-gnu) libcurl/7.88.1 OpenSSL/3.0.11 zlib/1.2.13 brotli/1.0.9 zstd/1.5.4 libidn2/2.3.3 libpsl/0.21.2 (+libidn2/2.3.3) libssh2/1.10.0 nghttp2/1.52.0 librtmp/2.3 OpenLDAP/2.5.13
Release-Date: 2023-02-20
Protocols: dict file ftp ftps gopher gophers http https imap imaps ldap ldaps mqtt pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli GSS-API HSTS HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM NTLM_WB PSL SPNEGO SSL threadsafe TLS-SRP UnixSockets zstd

dpkg -l | grep curl
ii  curl                                             7.88.1-10+deb12u4