### PR TITLE
[DELENG-365] Add catalog workflow to use whitelisted SHA

### DIFF
--- a/.github/workflows/catalog.yaml
+++ b/.github/workflows/catalog.yaml
@@ -1,0 +1,28 @@
+---
+name: Service Catalog
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - 4.x
+permissions:
+  contents: "read"
+  packages: "read"
+  id-token: "write"
+jobs:
+  docs:
+    if: "!contains(github.ref_name, '/')"
+    # SHA: 436c9e4b5ba68282956ffa169ae714827cf49bc5
+    # Source: service-catalog PR #113 merge commit (main branch, 2026-02-23)
+    # Allowlisted in: projects/pantheon-wif/workload-identity-federation.tf
+    # See: https://github.com/pantheon-systems/gce-terraform/blob/master/projects/pantheon-wif/workload-identity-federation.tf#L106
+    uses: pantheon-systems/service-catalog/.github/workflows/docs-like-code.yaml@436c9e4b5ba68282956ffa169ae714827cf49bc5  # main @ Feb 23, 2026
+  catalog-upload:
+    if: "!contains(github.ref_name, '/')"
+    # SHA: 436c9e4b5ba68282956ffa169ae714827cf49bc5
+    # Source: service-catalog PR #113 merge commit (main branch, 2026-02-23)
+    # This SHA is allowlisted in the pantheon-service-catalog WIF pool for production classification
+    # Allowlist location: projects/pantheon-wif/workload-identity-federation.tf (attribute.jwr_repo_file_env)
+    # See: https://github.com/pantheon-systems/gce-terraform/blob/master/projects/pantheon-wif/workload-identity-federation.tf#L106
+    uses: pantheon-systems/service-catalog/.github/workflows/catalog-upload.yaml@436c9e4b5ba68282956ffa169ae714827cf49bc5  # main @ Feb 23, 2026


### PR DESCRIPTION
**Note**: This PR creates a new catalog.yml workflow file.

## Summary
Updates the catalog workflow to use the whitelisted SHA from service-catalog with proper documentation.

## Changes
- Updates `docs` job to use service-catalog/.github/workflows/docs-like-code.yaml@436c9e4b5ba68282956ffa169ae714827cf49bc5
- Updates `catalog-upload` job to use service-catalog/.github/workflows/catalog-upload.yaml@436c9e4b5ba68282956ffa169ae714827cf49bc5
- Adds documentation comments explaining:
  - SHA source (service-catalog PR #113 merge commit)
  - WIF pool whitelist location
  - Production classification requirements

## Context
As part of the WIF pool migration (service-catalog PR #113), all repos using catalog workflows need to reference the whitelisted SHA. This SHA is specifically allowed in the `pantheon-service-catalog` WIF pool configuration for production access.

## Testing
- Workflow will use the new WIF pool: `pantheon-service-catalog` in project `pantheon-wif`
- Authentication will work with both `main` and `master` branches
- Secrets and GCS bucket access will use production credentials

## Related
- Ticket: DELENG-365
- Service Catalog PR: https://github.com/pantheon-systems/service-catalog/pull/113
- WIF Configuration: https://github.com/pantheon-systems/gce-terraform/blob/master/projects/pantheon-wif/workload-identity-federation.tf
